### PR TITLE
Update Chrome/Chromium regex to include minor patch version number

### DIFF
--- a/priv/patterns.yml
+++ b/priv/patterns.yml
@@ -449,8 +449,8 @@ user_agent_parsers:
   # Browser/major_version.minor_version
   - regex: '(bingbot|Bolt|AdobeAIR|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient|Dragon|Outlook-iOS-Android)/(\d+)\.(\d+)(?:\.(\d+))?'
 
-  # Chrome/Chromium/major_version.minor_version
-  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)(?:\.(\d+))?'
+  # Chrome/Chromium/major_version.minor_version.patch_version.minor_patch_version
+  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)(?:\.(\d+))(?:\.(\d+))?'
 
   ##########
   # IE Mobile needs to happen before Android to catch cases such as:


### PR DESCRIPTION
Updating my fork of the `ua_parser` to match the current master branch.